### PR TITLE
Fixes filename inconsistency for disabling GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Description=Disables Nvidia GPU on OS shutdown
 Type=oneshot
 RemainAfterExit=true
 ExecStart=/bin/true
-ExecStop=/bin/bash -c "mv /etc/modprobe.d/lock-nvidia.conf.disable /etc/modprobe.d/lock-nvidia.conf || true"
+ExecStop=/bin/bash -c "mv /etc/modprobe.d/disable-nvidia.conf.disable /etc/modprobe.d/disable-nvidia.conf || true"
 [Install]
 WantedBy=multi-user.target
 ```


### PR DESCRIPTION
Looks like this file is created and referred to in the enable/disable scripts as `/etc/modprobe.d/disable-nvidia.conf`, but in the `systemctl` service definition as `/etc/modprobe.d/lock-nvidia.conf`. This PR makes it consistent as `disable` instead of `lock` in the service definition as well.